### PR TITLE
Front-end homepage navbar index

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,8 @@
 // Your CSS partials
 @import "components/index";
 @import "pages/index";
+@import "pages/show";
+@import "pages/index";
 
 .form_container {
   padding:30px;

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -14,19 +14,38 @@
   color: rgba(255, 255, 255, 1);
 }
 
+// .new-item-button {
+//   color: #4A4A4A;
+//   border: 1px solid #4A4A4A;
+//   padding: 8px 24px;
+//   border-radius: 50px;
+//   font-weight:bold;
+//   opacity: 0.6;
+//   transition: opacity 0.3s ease;
+//   width: 11%;
+//   margin: auto;
+//   position: relative;
+//   text-decoration: none;
+// }
 
-.new-item-button {
-  color: #4A4A4A;
-  border: 1px solid #4A4A4A;
-  padding: 8px 24px;
-  border-radius: 50px;
-  font-weight:bold;
-  opacity: 0.6;
+.new-item-button a {
+  padding: 10px 20px;
+  border: 3px solid black;
+  background-color: black;
+  color: white;
+  text-decoration: none !important;
   transition: opacity 0.3s ease;
-  width: 11%;
-  margin: auto;
-  position: relative;
-  text-decoration: none;
+  font-size: 18px;
+  letter-spacing: 0.2rem;
+  margin: 10px;
+  width: 20%;
+}
+
+
+.new-item-button:hover a {
+  background-color: white;
+  border: 3px solid black;
+  color: rgba(255, 255, 255, 1);
 }
 
 .back_button {

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -43,3 +43,11 @@
 .footer-links a:hover {
   opacity: 0.5;
 }
+
+.footer-div {
+  align-items: left;
+}
+
+.navbar-brand {
+  margin-left: -15px;
+}

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -14,3 +14,18 @@
 .navbar-lewagon .navbar-brand img {
   width: 40px;
 }
+
+.logo-text {
+  margin-top: -20px;
+  padding-left: 40px;
+  color: rgb(177, 177, 177);
+}
+
+.navbar-brand {
+  margin: 0px;
+  padding: 0px;
+}
+
+.container-fluid {
+  max-height: 70px;
+}

--- a/app/assets/stylesheets/components/_product_card.scss
+++ b/app/assets/stylesheets/components/_product_card.scss
@@ -1,27 +1,40 @@
 .product-card {
   overflow: hidden;
   background: white;
-  box-shadow: 0 0 15px rgba(0,0,0,0.1);
+  box-shadow: 0 0 5px rgba(0,0,0,0.1);
   margin-bottom: 20px;
-  height: 480px;
+  // height: 350px;
+  // width: 300px;
+}
+
+.product-card:hover {
+  box-shadow: 0 0 15px rgba(140, 140, 140, 0.432);
+  border: 0.5px solid rgba(227, 227, 227, 0.919);
 }
 
 .product-card > img {
   width: 100%;
-  height: 350px;
+  height: 200px;
   object-fit: cover;
+  opacity: .8;
+}
+
+.product-card:hover > img {
+  opacity: .5;
 }
 
 .product-card h2 {
   font-size: 16px;
   font-weight: 500;
-  margin-bottom: 10px;
+  padding-bottom: 10px;
   text-align: left;
 }
 
 .product-card p {
   font-size: 12px;
   opacity: .7;
+  padding-top: 10px;
+  padding-bottom: 10px;
   margin: 0;
 }
 
@@ -32,4 +45,18 @@
   justify-content: space-between;
   align-items: flex-end;
   position: relative;
+}
+
+.product-card-title-price {
+  display: flex;
+  justify-content: space-between;
+}
+
+.product-card h2 {
+  padding: 0px;
+  margin: 0px;
+}
+
+.product-card a {
+  margin-top: 10px;
 }

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -4,3 +4,9 @@ h2 {
   margin-top: 5%;
   margin-bottom: 5%;
 }
+
+.price {
+  color: grey;
+  position: absolute;
+  right: -85%;
+}

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -1,2 +1,10 @@
 // Import page-specific CSS files here.
 @import "home";
+
+// .cards {
+// }
+
+.item-card {
+  font: 'Jost';
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/pages/_show.scss
+++ b/app/assets/stylesheets/pages/_show.scss
@@ -1,0 +1,56 @@
+@import "home";
+
+.added-item-banner {
+  background-color: black;
+  color: white;
+}
+
+
+
+.added-item-info {
+  margin: 15px;
+  background-color: white;
+  padding: 10px;
+  border-left: 2px solid black;
+}
+
+
+// .added-item-buttons {
+// }
+
+.added-item-buttons button {
+  padding: 10px 20px;
+  margin: 5px;
+  background-color: rgba(187, 187, 187, 0.8);
+  color: white;
+  text-decoration: none;
+  // FOR SOME REASON, THIS ISN'T WORKING - transition: opacity 0.3s ease;
+  border: 0;
+  font-size: 18px;
+  letter-spacing: 0.2rem;
+}
+
+.added-item-buttons button:hover {
+  background-color: black;
+  border: 0;
+  color: rgba(255, 255, 255, 1);
+}
+
+
+
+
+.added-item-info2 {
+  margin: 15px;
+  background-color: white;
+  padding: 10px;
+  border-left: 2px solid black;
+}
+
+.added-item-buttons2 {
+  display: inline;
+  justify-content: space-around;
+}
+
+.added-item-buttons2 btn {
+  flex-grow: 1;
+}

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,13 +1,27 @@
 <div class='container'>
 
-<h1 class='title_1'>Everything We Offer</h1>
-  <div class = 'cards'>
-  <% @items.each do |item| %>
-  <div class='item_card'>
-    <p><%= link_to item.name, item_path(item) %></p>
-    <p> <%= item.price %> </p>
-  </div>
-  <% end %>
+
+<div class="container">
+  <h2>All items available</h2>
+
+  <div class="row">
+      <div class="cards">
+        <% @items.each do |i| %>
+        <div class="product-card">
+        <%# <%= cl_image_tag i.photo.key, height: 300, width: 400, crop: :fill %>
+          <img src="https://images.unsplash.com/photo-1544457070-4cd773b4d71e?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1230&q=80" class="frontpage-replacement-images">
+            <div class="col-sm-6 product-card-infos">
+              <div>
+                <div class="product-card-title-price">
+                  <h2><%= i.name %></h2>
+                  <h2 class="price">£<%= i.price %></h2>
+                </div>
+                  <p><i class="fa-solid fa-chair"></i>  <%= i.category %></p>
+                <%= link_to "See item", item_path(i), class: "btn btn-dark" %>
+              </div>
+        </div>
+      </div>
+    <% end %>
   </div>
 
 <div class='new-item-button'>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -5,26 +5,30 @@
     <%= link_to "SHOP ALL", items_path, class: "btn-main" %>
   </div>
 </div>
+
 <div class="container">
   <h2>what's new?</h2>
   <div class="row">
-    <% @most_recent_items.each do |i| %>
       <div class="col-sm-6 col-md-4 col-lg-3">
+        <% @most_recent_items.each do |i| %>
         <div class="product-card">
-        <%= cl_image_tag i.photo.key, height: 300, width: 400, crop: :fill %>
-          <div class="product-card-infos">
-            <div>
-              <h2><%= i.name %></h2>
-              <p><%= i.category %></p>
-              <%= link_to "learn more", item_path(i), class: "btn btn-dark" %>
-            </div>
-            <h2 class="product-card-pricing">£<%= i.price %></h2>
-            </div>
+        <%# <%= cl_image_tag i.photo.key, height: 300, width: 400, crop: :fill %>
+          <img src="https://images.unsplash.com/photo-1544457070-4cd773b4d71e?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1230&q=80" class="frontpage-replacement-images">
+            <div class="col-sm-6 product-card-infos">
+              <div>
+                <div class="product-card-title-price">
+                  <h2><%= i.name %></h2>
+                  <h2 class="price">£<%= i.price %></h2>
+                </div>
+                  <p><i class="fa-solid fa-chair"></i>  <%= i.category %></p>
+                <%= link_to "See item", item_path(i), class: "btn btn-dark" %>
+              </div>
         </div>
       </div>
     <% end %>
   </div>
 </div>
+
 <h2>categories</h2>
 <div class="row">
   <div class="col-sm-12 col-md-6 category" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url(https://res.cloudinary.com/dqydndvhv/image/upload/v1661948076/g1hhiywpd3o3rwtv8thc.jpg)">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -13,7 +13,17 @@
       <a class="footer-link" href="#">Featured</a>
     </div>
       <div class="col-sm-12 col-md-12 col-lg-4 footer-div">
-        <h3 class="mb-3">LOGO</h3>
+       <h4 class="mb-3">obscure.</h4>
+        <div class="footer-logo-container">
+          <a href="/" class="navbar-brand">
+            <script src="https://cdn.lordicon.com/xdjxvujz.js"></script>
+              <lord-icon
+                  src="https://cdn.lordicon.com/zgbvvyzo.json"
+                  trigger="hover"
+                  colors="primary:#ffdd00,secondary:#0a8fd4,tertiary:#3a3347,quaternary:#a4d3c3"
+                  style="width:150px;height:70px">
+              </lord-icon>
+        </div>
         <div class="footer-links">
         <a href="#"><i class="fab fa-instagram"></i></a>
         <a href="#"><i class="fab fa-facebook"></i></a>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,6 +1,15 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
   <div class="container-fluid">
-      <a href="/" class="navbar-brand"><i class="fa-solid fa-couch"></i></a>
+      <a href="/" class="navbar-brand">
+        <script src="https://cdn.lordicon.com/xdjxvujz.js"></script>
+          <lord-icon
+              src="https://cdn.lordicon.com/zgbvvyzo.json"
+              trigger="hover"
+              colors="primary:#ffdd00,secondary:#0a8fd4,tertiary:#3a3347,quaternary:#a4d3c3"
+              style="width:150px;height:70px">
+          </lord-icon>
+          <p class="logo-text">obscure.</p>
+      </a>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
Not done with this unfortunately, but I've made some changes, merely suggestions:

Logo and pseudo-brand name in navbar (hover over logo for animation):
<img width="1432" alt="Screenshot 2022-09-01 at 00 26 44" src="https://user-images.githubusercontent.com/108680829/187802157-014f9113-388b-46a9-8959-74e26c7009fa.png">

Added cards to homepage for recent items - we still need to have them display inline. Can also be used for item cards in other pages:
<img width="1230" alt="Screenshot 2022-09-01 at 00 27 05" src="https://user-images.githubusercontent.com/108680829/187802444-941c3d41-38a8-4d12-b12f-a2877975798b.png">

Added brand name & animated logo to footer:
<img width="1404" alt="Screenshot 2022-09-01 at 00 28 32" src="https://user-images.githubusercontent.com/108680829/187802308-55341458-88f4-4a5f-bc15-f7d57e56d9f8.png">
For footer display issue (not displaying over the whole page), we might need to figure out how to get footer out of the body, so that it doesn't inherit the width constraint for the page body container (see here: https://stackoverflow.com/questions/14058455/footer-does-not-stretch-to-100-width)

Added cards to Items page:
<img width="1252" alt="Screenshot 2022-09-01 at 00 30 26" src="https://user-images.githubusercontent.com/108680829/187802496-e78435ad-f6a5-415d-b299-753d4d49a809.png">

Important note: since I didn't have Cloudinary access, I had to comment out a few stuff & add another pic so that the page could load at all (see lines 15-16 home.html.erb). Please feel free to revert! Also feel free to edit this request and get rid of changes you don't like :)
